### PR TITLE
handle privacy mode 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- handle optin cookie
 
 ## [0.1.0] - 2022-06-21
 ### Added

--- a/Symplify.Conversion.SDK.Tests/CompatibilityTest.cs
+++ b/Symplify.Conversion.SDK.Tests/CompatibilityTest.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text.Json;
 using Newtonsoft.Json.Linq;
 using RichardSzalay.MockHttp;
 

--- a/Symplify.Conversion.SDK.Tests/ConfigTest.cs
+++ b/Symplify.Conversion.SDK.Tests/ConfigTest.cs
@@ -139,7 +139,7 @@ namespace Symplify.Conversion.SDK.Tests
         ""updated"": 1648466732,
         ""projects"": [
             {
-            ""id"": 4711,
+                ""id"": 4711,
                 ""name"": ""discount"",
                 ""variations"": [
                     {
@@ -156,6 +156,20 @@ namespace Symplify.Conversion.SDK.Tests
                         ""id"": 9999,
                         ""name"": ""small""
                     }
+                ]
+            }
+        ]}";
+
+        private const string CONFIG_JSON_WITH_PRIVACY_MODE_2 = @"{
+        ""updated"": 1648466732,
+        ""privacy_mode"": 2,
+        ""projects"": [
+            {
+                ""id"": 4711,
+                ""name"": ""discount"",
+                ""variations"": [
+                    { ""id"": 42, ""name"": ""original"", ""weight"": 10 },
+                    { ""id"": 1337, ""name"": ""huge"", ""weight"": 2 }
                 ]
             }
         ]}";
@@ -227,6 +241,15 @@ namespace Symplify.Conversion.SDK.Tests
         {
             SymplifyConfig config = new SymplifyConfig(CONFIG_JSON_MISSING_PROJECT_PROPERTY);
             Assert.Equal((uint)1, config.Projects[0].Variations[2].Weight);
+        }
+
+        [Theory]
+        [InlineData(CONFIG_JSON_DISCOUNT, 0)]
+        [InlineData(CONFIG_JSON_WITH_BOM, 0)]
+        [InlineData(CONFIG_JSON_WITH_PRIVACY_MODE_2, 2)]
+        public void TestCanReadPrivacyMode(string json, uint privacyMode)
+        {
+            Assert.Equal(privacyMode, (new SymplifyConfig(json)).PrivacyMode);
         }
     }
 }

--- a/Symplify.Conversion.SDK.Tests/ConfigTest.cs
+++ b/Symplify.Conversion.SDK.Tests/ConfigTest.cs
@@ -245,7 +245,6 @@ namespace Symplify.Conversion.SDK.Tests
 
         [Theory]
         [InlineData(CONFIG_JSON_DISCOUNT, 0)]
-        [InlineData(CONFIG_JSON_WITH_BOM, 0)]
         [InlineData(CONFIG_JSON_WITH_PRIVACY_MODE_2, 2)]
         public void TestCanReadPrivacyMode(string json, uint privacyMode)
         {

--- a/Symplify.Conversion.SDK.Tests/data/test_cases.json
+++ b/Symplify.Conversion.SDK.Tests/data/test_cases.json
@@ -144,7 +144,6 @@
     "expect_sg_cookie_properties_match": {}
   },
   {
-    "skip": "not yet implemented",
     "test_name": "bail out if privacy mode 2 and no opt-in",
     "sdk_config": "sdk_config_privacy2.json",
     "website_id": "10001",
@@ -155,7 +154,6 @@
     }
   },
   {
-    "skip": "not yet implemented",
     "test_name": "no bail out if privacy mode 2 but opt-in set",
     "sdk_config": "sdk_config_privacy2.json",
     "website_id": "10001",

--- a/Symplify.Conversion.SDK/Allocation/Config/SymplifyConfig.cs
+++ b/Symplify.Conversion.SDK/Allocation/Config/SymplifyConfig.cs
@@ -38,6 +38,7 @@ namespace Symplify.Conversion.SDK.Allocation.Config
 
                 Updated = config.Updated;
                 Projects = config.Projects;
+                PrivacyMode = config.PrivacyMode;
             }
             catch (Exception ex)
             {
@@ -60,6 +61,12 @@ namespace Symplify.Conversion.SDK.Allocation.Config
         /// </summary>
         [JsonPropertyName("updated")]
         public long Updated { get; set; }
+
+        /// <summary>
+        /// Gets or sets the site privacy mode.
+        /// </summary>
+        [JsonPropertyName("privacy_mode")]
+        public uint PrivacyMode { get; set; }
 
         /// <summary>
         /// Gets or sets the current projects.

--- a/Symplify.Conversion.SDK/SymplifyClient.cs
+++ b/Symplify.Conversion.SDK/SymplifyClient.cs
@@ -125,7 +125,8 @@ namespace Symplify.Conversion.SDK
                 return null;
             }
 
-            if (Config.PrivacyMode == 2 && cookieJar.GetCookie("sg_optin") != "1") {
+            if (Config.PrivacyMode == 2 && cookieJar.GetCookie("sg_optin") != "1")
+            {
                 return null;
             }
 

--- a/Symplify.Conversion.SDK/SymplifyClient.cs
+++ b/Symplify.Conversion.SDK/SymplifyClient.cs
@@ -125,6 +125,10 @@ namespace Symplify.Conversion.SDK
                 return null;
             }
 
+            if (Config.PrivacyMode == 2 && cookieJar.GetCookie("sg_optin") != "1") {
+                return null;
+            }
+
             var sympCookie = SymplifyCookie.FromCookies(currentWebsiteID, cookieJar);
             if (!sympCookie.IsSupported())
             {


### PR DESCRIPTION
Why?
====

Privacy mode 2 (opt in for cookie use) is a feature of our SDK. This .NET library did just not implement it yet.

Testing
======

* add unit tests for privacy mode field
* "unskip" privacy mode compatibility tests