### PR TITLE
stricter types, compatibility test for hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- add hash function tests
 
 ## [0.2.0] - 2022-06-23
 ### Added

--- a/Symplify.Conversion.SDK.Tests/HashInWindow.cs
+++ b/Symplify.Conversion.SDK.Tests/HashInWindow.cs
@@ -12,7 +12,7 @@ namespace Symplify.Conversion.SDK.Tests
         [InlineData("Fabian", 586, 1_000)] // can scale up
         [InlineData("Alexander", 1, 1)] // can scale down
         [InlineData("Fabian", 2, 2)] // can scale down
-        public void HashInWindowIsNotRandom(string str, int expected, uint windowSize)
+        public void HashInWindowIsNotRandom(string str, uint expected, uint windowSize)
         {
             Assert.Equal(expected, CustomHash.HashInWindow(str, windowSize));
         }
@@ -21,9 +21,17 @@ namespace Symplify.Conversion.SDK.Tests
         [InlineData("9e66a7fa-984a-4681-9319-80c2be2ffe8a", 1)]
         [InlineData("72784e9c-f5ae-4aed-8ae7-baa9c6e31d3c", 2)]
         [InlineData("cc615f71-1ab8-4322-b7d7-e10294a8d483", 3)]
-        public void hashInWindowIsDistributed(string str, int expected)
+        public void hashInWindowIsDistributed(string str, uint expected)
         {
             Assert.Equal(expected, CustomHash.HashInWindow(str, 3));
+        }
+
+
+        [Theory]
+        [InlineData("b7850777-f581-4f66-ad3e-4e54963661df", 100, 57)]
+        public void hashInWindowIsCompatible(string str, uint window, uint expected)
+        {
+            Assert.Equal(expected, CustomHash.HashInWindow(str, window));
         }
     }
 }

--- a/Symplify.Conversion.SDK/Allocation/Allocation.cs
+++ b/Symplify.Conversion.SDK/Allocation/Allocation.cs
@@ -20,7 +20,7 @@ namespace Symplify.Conversion.SDK.Allocation
                 return null;
             }
 
-            int allocation = GetAllocation(project, visitorId);
+            uint allocation = GetAllocation(project, visitorId);
 
             var variation = LookupVariationAt(project, allocation);
 
@@ -32,7 +32,7 @@ namespace Symplify.Conversion.SDK.Allocation
             return variation;
         }
 
-        private static int GetAllocation(ProjectConfig project, string visitorId)
+        private static uint GetAllocation(ProjectConfig project, string visitorId)
         {
             string hashKey = string.Format(CultureInfo.InvariantCulture, "{0}:{1}", visitorId, project.ID);
             uint totalWeight = 100;
@@ -40,7 +40,7 @@ namespace Symplify.Conversion.SDK.Allocation
             return CustomHash.HashInWindow(hashKey, totalWeight);
         }
 
-        private static VariationConfig LookupVariationAt(ProjectConfig project, int allocation)
+        private static VariationConfig LookupVariationAt(ProjectConfig project, uint allocation)
         {
             uint totalWeight = 0;
             List<(uint weight, long id)> variationThresholds = new();

--- a/Symplify.Conversion.SDK/CustomHash.cs
+++ b/Symplify.Conversion.SDK/CustomHash.cs
@@ -5,29 +5,33 @@ namespace Symplify.Conversion.SDK
     /// <summary>
     /// CustomHash houses functions for SDK specific hashing we need for compatibility reasons.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop", "SA1121: Use built-in type alias", Justification = "we want to be sure hash is 32 bit")]
     public static class CustomHash
     {
         /// <summary>
         /// Hash the given string key and scale the hash result to fit within the given window.
         /// </summary>
-        public static int HashInWindow(string key, uint window)
+        public static UInt32 HashInWindow(string key, uint window)
         {
-            uint unsignedMax = 4_294_967_295;
+            UInt32 unsignedMax = 4_294_967_295;
 
+            // we need a higher precision floating point value for the scaling operation
             double hash = Djb2Xor(key);
 
             // scale hash to the desired window
             hash /= unsignedMax;
-            return (int)Math.Ceiling(hash * window);
+            hash *= window;
+
+            return (UInt32)Math.Ceiling(hash);
         }
 
         /// <summary>
         /// Hash the given string using the djb2 algorithm, xor variant.
         /// See http://www.cse.yorku.ca/~oz/hash.html.
         /// </summary>
-        public static ulong Djb2Xor(string str)
+        public static UInt32 Djb2Xor(string str)
         {
-            ulong hash = 5381;
+            UInt32 hash = 5381;
 
             for (var i = 0; i < str.Length; i += 1)
             {


### PR DESCRIPTION
When testing the Node.js version we found a bug in its windowed hash function.

The bug is not in this .NET code, but the test identifying the bug was missing, so let's add it.

Bonus fix: make the hash return types explicitly 32 bit, to match our other SDK platforms.