### PR TITLE
Add .NET Framework 4 target

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,8 +1,8 @@
-name: .NET CI
+name: .NET 6 CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "feature/**" ]
   pull_request:
     branches: [ "main" ]
 
@@ -21,7 +21,5 @@ jobs:
       run: dotnet restore
     - name: Lint
       run: ci/lint.sh
-    - name: Build
-      run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: ci/test_net6.0.sh

--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -1,0 +1,29 @@
+name: .NET Framework 4.7 CI
+
+on:
+  push:
+    branches: [ "main", "feature/**" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET (for building)
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 6.0.x
+    - name: Setup Mono (for running)
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install mono-devel nuget
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Lint
+      run: ci/lint.sh
+    - name: Test
+      run: ci/test_net47.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- add support for .NET Framework 4.7
 - add hash function tests
 
 ## [0.2.0] - 2022-06-23

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Requirements:
 
+- [.NET](https://dotnet.microsoft.com/en-us/download)
+- (for .NET Framework 4.7 support outside Windows) [Mono](https://www.mono-project.com/download/stable/)
 - [Caddy](https://caddyserver.com)
 
 1. Clone this repository
@@ -15,8 +17,15 @@ dotnet test
 
 ## Unit Testing
 
-The project `Symplify.Conversion.SDK.Tests` contains all the test files. Run `dotnet test`
-to run the tests.
+The project `Symplify.Conversion.SDK.Tests` contains all the test code. Run
+`dotnet test` to run the tests for all target frameworks.
+
+If your `dotnet` CLI does not handle all target frameworks (e.g. you are on macOS), you will have to test them separately:
+
+```shell
+./ci/test_net6.0.sh
+./ci/test_net47.sh
+```
 
 ## Testing with a local site
 

--- a/Symplify.Conversion.SDK.DemoApp/Symplify.Conversion.SDK.DemoApp.csproj
+++ b/Symplify.Conversion.SDK.DemoApp/Symplify.Conversion.SDK.DemoApp.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Symplify.Conversion.SDK.Tests/CompatibilityTest.cs
+++ b/Symplify.Conversion.SDK.Tests/CompatibilityTest.cs
@@ -108,8 +108,9 @@ namespace Symplify.Conversion.SDK.Tests
             await client.LoadConfig();
 
             // prepare the per request data
-            RawCookieJar cookieJar = new();
-            foreach (var cookie in test?.Cookies ?? new())
+            RawCookieJar cookieJar = new RawCookieJar();
+            Dictionary<string, string> testCookies = test?.Cookies ?? new Dictionary<string, string>();
+            foreach (var cookie in testCookies)
             {
                 // the test data has encoded cookies, but our raw cookie jar for tests doesn't have any codec
                 cookieJar.SetCookie(cookie.Key, WebUtility.UrlDecode(cookie.Value), 99);
@@ -129,7 +130,7 @@ namespace Symplify.Conversion.SDK.Tests
                 foreach (var part in expect.Name.Split('/'))
                 {
                     // traverse to an expected leaf
-                    if (node is not JObject)
+                    if (!(node is JObject))
                     {
                         break;
                     }

--- a/Symplify.Conversion.SDK.Tests/CookieTest.cs
+++ b/Symplify.Conversion.SDK.Tests/CookieTest.cs
@@ -59,7 +59,7 @@ namespace Symplify.Conversion.SDK.Tests
         [Fact]
         public void TestCreateFromScratch()
         {
-            SymplifyCookie cookie = new("anything");
+            SymplifyCookie cookie = new SymplifyCookie("anything");
             Assert.Equal(1, cookie.GetVersion());
         }
 
@@ -92,7 +92,7 @@ namespace Symplify.Conversion.SDK.Tests
         {
             int projectID = 1337;
             int variationID = 42;
-            SymplifyCookie cookie = new("4711");
+            SymplifyCookie cookie = new SymplifyCookie("4711");
             cookie.SetAllocatedVariationID(projectID, variationID);
             Assert.Equal(variationID, cookie.GetAllocatedVariationID(projectID));
         }
@@ -101,7 +101,7 @@ namespace Symplify.Conversion.SDK.Tests
         public void TestAllocatedProjectSet()
         {
             int projectID = 1337;
-            SymplifyCookie cookie = new("some site id");
+            SymplifyCookie cookie = new SymplifyCookie("some site id");
 
             cookie.SetAllocatedVariationID(projectID, 42);
             Assert.Equal(42, cookie.GetAllocatedVariationID(projectID));

--- a/Symplify.Conversion.SDK.Tests/EnsureVisitorID.cs
+++ b/Symplify.Conversion.SDK.Tests/EnsureVisitorID.cs
@@ -13,7 +13,7 @@ namespace Symplify.Conversion.SDK.Tests
         [Fact]
         public void TestSetCookie()
         {
-            SymplifyCookie sympCookie = new("TestSite");
+            SymplifyCookie sympCookie = new SymplifyCookie("TestSite");
             string returnedID = Visitor.EnsureVisitorID(sympCookie, () => "goober");
 
             Assert.Equal("goober", returnedID);
@@ -23,7 +23,7 @@ namespace Symplify.Conversion.SDK.Tests
         [Fact]
         public void TestReuseCookie()
         {
-            SymplifyCookie sympCookie = new("TestSite");
+            SymplifyCookie sympCookie = new SymplifyCookie("TestSite");
             sympCookie.SetVisitorID("goober");
 
             string returnedID = Visitor.EnsureVisitorID(sympCookie, () => "foobar");
@@ -34,8 +34,8 @@ namespace Symplify.Conversion.SDK.Tests
         [Fact]
         public void TestGenerateUUID()
         {
-            string returnedIDA = Visitor.EnsureVisitorID(new("TestSite"));
-            string returnedIDB = Visitor.EnsureVisitorID(new("TestSite"));
+            string returnedIDA = Visitor.EnsureVisitorID(new SymplifyCookie("TestSite"));
+            string returnedIDB = Visitor.EnsureVisitorID(new SymplifyCookie("TestSite"));
 
             string uuidPattern = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
             Assert.Matches(uuidPattern, returnedIDA);

--- a/Symplify.Conversion.SDK.Tests/Loggingtest.cs
+++ b/Symplify.Conversion.SDK.Tests/Loggingtest.cs
@@ -10,9 +10,9 @@ namespace Symplify.Conversion.SDK.Tests
         [Fact]
         public void testErrorLog()
         {
-            LogSpy logSpy = new();
-            ClientConfig cfg = new("4711", "https://localhost:10000");
-            SymplifyClient sdk = new(cfg, new HttpClient(), logSpy);
+            LogSpy logSpy = new LogSpy();
+            ClientConfig cfg = new ClientConfig("4711", "https://localhost:10000");
+            SymplifyClient sdk = new SymplifyClient(cfg, new HttpClient(), logSpy);
             List<string> projects = sdk.ListProjects();
 
             Assert.Empty(projects);

--- a/Symplify.Conversion.SDK.Tests/Symplify.Conversion.SDK.Tests.csproj
+++ b/Symplify.Conversion.SDK.Tests/Symplify.Conversion.SDK.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-
+    <TargetFrameworks>net47;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -29,5 +28,12 @@
     <None Include="data\sdk_config.json" CopyToOutputDirectory="PreserveNewest" />
     <None Include="data\sdk_config_privacy2.json" CopyToOutputDirectory="PreserveNewest" />
     <None Include="data\test_cases.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
+    <PackageReference Include="xunit.runner.console" Version="2.4.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/Symplify.Conversion.SDK/Allocation/Allocation.cs
+++ b/Symplify.Conversion.SDK/Allocation/Allocation.cs
@@ -43,7 +43,7 @@ namespace Symplify.Conversion.SDK.Allocation
         private static VariationConfig LookupVariationAt(ProjectConfig project, uint allocation)
         {
             uint totalWeight = 0;
-            List<(uint weight, long id)> variationThresholds = new();
+            List<(uint weight, long id)> variationThresholds = new List<(uint weight, long id)>();
 
             foreach (VariationConfig variationConfig in project.Variations)
             {

--- a/Symplify.Conversion.SDK/Cookies/CookieJar.cs
+++ b/Symplify.Conversion.SDK/Cookies/CookieJar.cs
@@ -8,12 +8,12 @@
         /// <summary>
         /// Gets the value of the cookie with the given name. Decode it if your web framework does not do that.
         /// </summary>
-        public string GetCookie(string name);
+        string GetCookie(string name);
 
         /// <summary>
         /// Sets the cookie with the given name to the given value. Encode it if your web framework does not do that.
         /// The cookie should be set for your zone apex domain (see https://www.rfc-editor.org/rfc/rfc8499).
         /// </summary>
-        public void SetCookie(string name, string value, uint expireInDays);
+        void SetCookie(string name, string value, uint expireInDays);
     }
 }

--- a/Symplify.Conversion.SDK/Cookies/SymplifyCookie.cs
+++ b/Symplify.Conversion.SDK/Cookies/SymplifyCookie.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Net;
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/Symplify.Conversion.SDK/Cookies/SymplifyCookie.cs
+++ b/Symplify.Conversion.SDK/Cookies/SymplifyCookie.cs
@@ -47,7 +47,7 @@ namespace Symplify.Conversion.SDK.Cookies
         /// Initializes a new instance of the <see cref="SymplifyCookie"/> class.
         /// </summary>
         public SymplifyCookie(string websiteID)
-        : this(websiteID, new())
+        : this(websiteID, new JObject())
         {
         }
 
@@ -74,7 +74,7 @@ namespace Symplify.Conversion.SDK.Cookies
 
             if (cookieJSON == null)
             {
-                return new(websiteID);
+                return new SymplifyCookie(websiteID);
             }
 
             return SymplifyCookie.FromJSON(websiteID, cookieJSON);
@@ -86,7 +86,7 @@ namespace Symplify.Conversion.SDK.Cookies
         public static SymplifyCookie FromJSON(string websiteID, string value)
         {
             var underlying = JObject.Parse(value);
-            return new(websiteID, underlying);
+            return new SymplifyCookie(websiteID, underlying);
         }
 
         /// <summary>

--- a/Symplify.Conversion.SDK/Symplify.Conversion.SDK.csproj
+++ b/Symplify.Conversion.SDK/Symplify.Conversion.SDK.csproj
@@ -16,7 +16,7 @@
 
   <!-- Build settings -->
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net47;net6.0</TargetFrameworks>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest-Recommended</AnalysisLevel>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -29,9 +29,9 @@
     <None Remove="Allocation\" />
     <None Remove="Cookies\" />
     <None Remove="NuGet.Build.Packaging" />
-    <None Include="../CHANGELOG.md" Pack="true" PackagePath=""/>
-    <None Include="../LICENSE" Pack="true" PackagePath=""/>
-    <None Include="../README.md" Pack="true" PackagePath=""/>
+    <None Include="../CHANGELOG.md" Pack="true" PackagePath="" />
+    <None Include="../LICENSE" Pack="true" PackagePath="" />
+    <None Include="../README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>
@@ -50,5 +50,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <!--
+    Some namespaces we use are not in .NET Framework 4.7,
+    so need to be pulled in as dependencies.
+  -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.Json" Version="6.0.5" />
   </ItemGroup>
 </Project>

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -24,7 +24,8 @@ dotnet restore
 
 dotnet build --configuration release /p:Version="$VERSION"
 
-dotnet test --configuration release /p:Version="$VERSION" --no-build
+# sanity check test
+dotnet test -f net6.0 --configuration release /p:Version="$VERSION" --no-build
 
 dotnet pack Symplify.Conversion.SDK --configuration Release /p:Version="$VERSION" --no-build --output .
 

--- a/ci/test_net47.sh
+++ b/ci/test_net47.sh
@@ -1,0 +1,25 @@
+#! /bin/sh
+
+set -u
+set -x
+
+if nuget help locals >/dev/null
+then
+    NUGET_PACKAGES_DIR=$(nuget locals global-packages -list | cut -d' ' -f2)
+else
+    NUGET_PACKAGES_DIR=~/.nuget/packages
+    echo "nuget command 'locals' is not available, assuming global packages dir is: $NUGET_PACKAGES_DIR"
+fi
+
+set -e
+
+XUNIT_VERSION=2.4.2
+PROJECT=Symplify.Conversion.SDK.Tests
+CONFIGURATION=Release
+
+# the nuget version in Ubuntu does not provide a "locals" command, so we assume the path
+XUNIT_TOOLS_DIR="$NUGET_PACKAGES_DIR"/xunit.runner.console/"$XUNIT_VERSION"/tools
+XUNIT_RUNNER_EXE="$XUNIT_TOOLS_DIR"/net472/xunit.console.exe
+
+dotnet build --configuration "$CONFIGURATION" --no-restore
+mono "$XUNIT_RUNNER_EXE" "$PROJECT"/bin/"$CONFIGURATION"/net47/"$PROJECT".dll

--- a/ci/test_net6.0.sh
+++ b/ci/test_net6.0.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+set -eu
+set -x
+
+dotnet test --configuration Release -f net6.0 --verbosity normal --no-restore


### PR DESCRIPTION
Why
===

We want to provide the SDK for users who have not yet upgraded to .NET (Core) from .NET Framework.

Since the SDK does not have many dependencies it does not require much changes to our code, we only have to stop using  some nice-to-haves from newer C# versions.

Changes
=======

* stop using C# 9 conveniences
* add `net47` as a target framework
* add CI workflow for testing with .NET 4.7 (relying on Mono)

By adding the new target framework, the NuGet package will contain multiple versions.