### PR TITLE
Release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2023-03-20
+
 ### Changed
 - add reference in documentation to [SST-documentation](https://github.com/SymplifyConversion/sst-documentation/)
   repository regarding cookie usage and setup
@@ -38,7 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - A first version of the SDK for .NET
 
-[Unreleased]: https://github.com/SymplifyConversion/sst-sdk-dotnet/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/SymplifyConversion/sst-sdk-dotnet/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/SymplifyConversion/sst-sdk-dotnet/releases/tag/v0.5.2
 [0.5.1]: https://github.com/SymplifyConversion/sst-sdk-dotnet/releases/tag/v0.5.1
 [0.5.0]: https://github.com/SymplifyConversion/sst-sdk-dotnet/releases/tag/v0.5.0
 [0.3.0]: https://github.com/SymplifyConversion/sst-sdk-dotnet/releases/tag/v0.3.0


### PR DESCRIPTION
### Changed
- add reference in documentation to [SST-documentation](https://github.com/SymplifyConversion/sst-documentation/) repository regarding cookie usage and setup