### PR TITLE
CT-2270 explicit cast to ICollection to help the runtime

### DIFF
--- a/Symplify.Conversion.SDK/Audience/RulesEngine.cs
+++ b/Symplify.Conversion.SDK/Audience/RulesEngine.cs
@@ -189,10 +189,13 @@ namespace Symplify.Conversion.SDK.Audience
                     throw new InvalidOperationException(string.Format("message: can only apply strings, {0} is not a string", car));
                 }
 
-                if (!primitives.Contains(car))
+#pragma warning disable IDE0004
+                //this cast is important, trust me! (not sure if other types are expected, though))
+                if (!(primitives as ICollection<string>)?.Contains(car))
                 {
                     throw new InvalidOperationException(string.Format("message: {0} is not a primitive", car));
                 }
+#pragma warning restore IDE0004
 
                 var cdr = ast.AfterSelf();
 


### PR DESCRIPTION
@RobertDahlin 
Ja denna är ju lite störig. Man måste alltså göra en rätt ful cast för att hjälpa runtime:n att förstå att det faktiskt finns en ".Contains"
Ni kanske kan fundera över om det någonsin kan komma nåt som inte implementerar ICollection<string> här (det är ju rätt mycket "dynamic" på vägen...)

Jag la in en #pragma eftersom Visual Studio tyckte att jag var galen, men den som sa det hen var det.